### PR TITLE
chore: PyPI packaging — classifiers, MANIFEST.in, CHANGELOG, single-s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [1.0.0] - 2026-04-21
+
+### Added
+- UniDock2 docking backend alongside existing Vina (`--docking_engine unidock2`)
+- Multi-chain receptor support
+- YAML input mode for per-ligand metadata
+- `--reference-ligand` to auto-define docking box from a reference PDB
+- `--mask_ligand_coords` for NoPose ablation benchmarks
+- `boltzina setup --all` for one-command dependency setup
+- Full test suite (73 tests)
+
+### Changed
+- Rewritten as a structured installable package (`boltzina.engine`, `boltzina.runner`, etc.)
+- Startup time reduced from ~8 s to <1 s (lazy imports)
+
+### Removed
+- `boltzina_main.py` (replaced by `boltzina.engine.Boltzina`)
+- `setup.sh`, `example_usage.py`, `ligand_preparation.py`, `INPUT_FORMAT.md`

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,10 @@
+global-exclude __pycache__
+global-exclude *.py[cod]
+prune boltzina.egg-info
+prune tests
+prune sample
+prune scripts
+prune local
+prune .venv
+exclude mf-pcba_test.zip
+exclude maxit.log

--- a/boltzina/__init__.py
+++ b/boltzina/__init__.py
@@ -1,5 +1,6 @@
-# Boltzina package initialization
-__version__ = "1.0.0"
+from importlib.metadata import version as _v
+
+__version__ = _v("boltzina")
 
 # Heavy imports (torch, boltz, rdkit) are NOT loaded here.
 # Import explicitly when needed:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,14 @@ authors = [
 ]
 keywords = ["virtual screening", "molecular docking", "protein-ligand binding", "boltz", "affinity prediction"]
 classifiers = [
-    "Programming Language :: Python :: 3",
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Topic :: Scientific/Engineering :: Chemistry",
 ]
@@ -32,8 +38,10 @@ dependencies = [
 ]
 
 [project.urls]
+Homepage  = "https://github.com/ohuelab/boltzina"
 Repository = "https://github.com/ohuelab/boltzina"
 Issues = "https://github.com/ohuelab/boltzina/issues"
+Changelog = "https://github.com/ohuelab/boltzina/blob/main/CHANGELOG.md"
 
 [project.scripts]
 boltzina = "boltzina.cli:main"


### PR DESCRIPTION
…ource version

- pyproject.toml: add Development Status/OS/Python version classifiers, Homepage + Changelog URLs
- boltzina/__init__.py: replace static __version__ with importlib.metadata.version
- MANIFEST.in: exclude tests, scripts, local, .venv, mf-pcba_test.zip from sdist
- CHANGELOG.md: initial 1.0.0 entry (Keep a Changelog format)
- git rm mf-pcba_test.zip (35 MB paper-repro dataset; available in git history)